### PR TITLE
Allow ruby-head to fail and not break the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ rvm:
   - 2.1.0
   - 2.0.0
   - 2.2.0
-  - ruby-head
   - 1.9.3
 notifications:
   email: false
-matrix:
-  allow_failures:
-    - ruby-head
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ rvm:
   - 1.9.3
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - ruby-head
+  


### PR DESCRIPTION
Since this depends on some C extensions (via coveralls), those are going to lag behind
ruby-head, so let's not have them fail the build.

Alternative is to remove coveralls, which I'd rather not do unless no one likes it :)